### PR TITLE
Explicit SSE2 vectorization with portable emulation

### DIFF
--- a/scipy/spatial/ckdtree/src/vec2d.h
+++ b/scipy/spatial/ckdtree/src/vec2d.h
@@ -1,0 +1,83 @@
+
+#ifdef __SSE2__
+#include <emmintrin.h>
+
+struct ckdtree_vec2d
+{
+    __m128d x;
+
+    ckdtree_vec2d operator + (ckdtree_vec2d rhs) const
+    {
+        return {_mm_add_pd(x, rhs.x)};
+    }
+    ckdtree_vec2d operator - (ckdtree_vec2d rhs) const
+    {
+        return {_mm_sub_pd(x, rhs.x)};
+    }
+    ckdtree_vec2d operator * (ckdtree_vec2d rhs) const
+    {
+        return {_mm_mul_pd(x, rhs.x)};
+    }
+
+    static ckdtree_vec2d loadu(const double * data)
+    {
+        return {_mm_loadu_pd(data)};
+    }
+
+    static ckdtree_vec2d from_scalar(double data)
+    {
+        return {_mm_set_sd(data)};
+    }
+
+    static ckdtree_vec2d splat(double data)
+    {
+        return {_mm_set_pd1(data)};
+    }
+
+    double sum() const
+    {
+        return x[0] + x[1];
+    }
+};
+
+#else // __SSE2__
+
+struct ckdtree_vec2d
+{
+    double x[2];
+
+    ckdtree_vec2d operator + (ckdtree_vec2d rhs) const
+    {
+        return {{x[0] + rhs.x[0], x[1] + rhs.x[1]}};
+    }
+    ckdtree_vec2d operator - (ckdtree_vec2d rhs) const
+    {
+        return {{x[0] - rhs.x[0], x[1] - rhs.x[1]}};
+    }
+    ckdtree_vec2d operator * (ckdtree_vec2d rhs) const
+    {
+        return {{x[0] * rhs.x[0], x[1] * rhs.x[1]}};
+    }
+
+    static ckdtree_vec2d loadu(const double * data)
+    {
+        return {{data[0], data[1]}};
+    }
+
+    static ckdtree_vec2d from_scalar(double data)
+    {
+        return {{data, 0.}};
+    }
+
+    static ckdtree_vec2d splat(double data)
+    {
+        return {{data, data}};
+    }
+
+    double sum() const
+    {
+        return x[0] + x[1];
+    }
+};
+
+#endif


### PR DESCRIPTION
I noticed that gcc wasn't using vector load instructions for the `_u` and `_v` vectors. Using explicit vector intrinsics gives a slight performance improvement and means windows can benefit as well.

Compared to your latest version this performs the same for `1 <= n < 4`, is around 6% faster for for `4 <= n < 10`, 10% faster for `10 <= n < 16` and 20% faster for `16 <= n` tested up to 64 dimensions. Usual caveat of this being for my hardware/compiler compiler combination. However, I would expect intrinsics to be less compiler dependent.

